### PR TITLE
Fix dsh bundle entry and release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 本项目采用[语义化版本](https://semver.org/lang/zh-CN/)。
 
+## [v0.3.1] - 2026-08-23
+
+### 修复
+
+- 新增无依赖的 dsh Cordis entry，按官方 `ctx.skills` provider 注册根目录 `SKILL.md`。
+- 补齐 `package.json` 的 `main` / `exports`，避免 bundle patch 解析到自身时触发 `ERR_MODULE_NOT_FOUND`。
+- 更新 dsh 安装说明，明确使用 `dsh plugin --profile web add` 并重启 Web profile。
+
 ## [v0.3.0] - 2026-08-23
 
 ### 新增

--- a/README.md
+++ b/README.md
@@ -116,13 +116,13 @@ git clone https://github.com/mudden2380078550-creator/write-chinese-long-screenp
   "$HOME\.codex\skills\write-chinese-long-screenplay"
 ```
 
-DeepSeek Harness 用户也可以直接以 bundle 安装（`package.json` 声明了 `dsh.bundle`）：
+DeepSeek Harness 用户也可以直接以 bundle 安装（包内含 Cordis entry，会把根目录 `SKILL.md` 注册到 dsh 技能目录）：
 
 ```sh
-dsh plugin add "github:mudden2380078550-creator/write-chinese-long-screenplay"
+dsh plugin --profile web add "github:mudden2380078550-creator/write-chinese-long-screenplay"
 ```
 
-安装后新建任务；若 skill 未出现，请重启对应 Agent。dsh 会监听 skills 目录变化并自动更新技能目录。
+安装后重启 `dsh web`；新会话中应能看到 `write-chinese-long-screenplay`。
 
 ## 初始化 v2 项目
 
@@ -251,7 +251,9 @@ python "<skill-dir>\scripts\validate_novel_project.py" `
   --strict
 ```
 
-初始化剧本项目仍使用原参数；不写 `--mode` 时默认 `screenplay`。小说模板和决策门禁说明见 `assets/novel-project-template/`、`references/novel-mode.md` 和 `references/decision-gates.md`。
+初始化剧本项目仍使用原参数；不写 `--mode` 时默认 `screenplay`。
+
+本仓库的 dsh bundle 入口是 `index.js`，它只注册 Skill，不额外注册工具；`cordis.patch.yml` 与 `package.json#main` 必须一起保留。小说模板和决策门禁说明见 `assets/novel-project-template/`、`references/novel-mode.md` 和 `references/decision-gates.md`。
 ## 版权与方法来源
 
 本 Skill 的概念映射参考了悉德·菲尔德的电影剧本结构方法、罗伯特·麦基的故事与对白方法，以及布莱克·斯奈德的电影编剧方法；去 AI 味检查分类参考了 [Humanizer-zh](https://github.com/op7418/Humanizer-zh) 公开的中文问题清单。仓库只包含原创的术语矩阵、工作流、模板和校验代码，不包含书籍文件、长篇原文或可替代原书的章节摘要。

--- a/README_EN.md
+++ b/README_EN.md
@@ -117,13 +117,13 @@ git clone https://github.com/mudden2380078550-creator/write-chinese-long-screenp
   "$HOME\.codex\skills\write-chinese-long-screenplay"
 ```
 
-DeepSeek Harness users can also install it directly as a bundle (its `package.json` declares `dsh.bundle`):
+DeepSeek Harness users can install it as a bundle (the package includes a Cordis entry that registers the root `SKILL.md`):
 
 ```sh
-dsh plugin add "github:mudden2380078550-creator/write-chinese-long-screenplay"
+dsh plugin --profile web add "github:mudden2380078550-creator/write-chinese-long-screenplay"
 ```
 
-After installation, start a new task; restart the agent if the skill does not appear. dsh watches its skills directory and updates the catalog automatically.
+Restart `dsh web` after installation; a new session should list `write-chinese-long-screenplay`.
 
 ## Initialize a v2 project
 

--- a/index.js
+++ b/index.js
@@ -1,0 +1,76 @@
+import { readFileSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+
+const skillName = 'write-chinese-long-screenplay';
+const skillPath = fileURLToPath(new URL('./SKILL.md', import.meta.url));
+const resourceBase = fileURLToPath(new URL('./', import.meta.url));
+const rank = 600;
+
+export const name = skillName;
+export const inject = ['skills'];
+
+export function apply(ctx) {
+  const initial = parseSkill(readFileSync(skillPath, 'utf8'));
+  if (initial === undefined) {
+    throw new Error(`${skillName}: root SKILL.md has invalid frontmatter`);
+  }
+
+  ctx.skills.registerProvider(() => ({
+    name: skillName,
+    async list(options) {
+      options?.signal?.throwIfAborted();
+      return [toCandidate(await loadSkill())];
+    },
+    async get(candidate, options) {
+      options?.signal?.throwIfAborted();
+      if (candidate.name !== skillName) return undefined;
+      return toDefinition(await loadSkill());
+    },
+  }));
+}
+
+async function loadSkill() {
+  const raw = await readFile(skillPath, 'utf8');
+  const skill = parseSkill(raw);
+  if (skill === undefined) {
+    throw new Error(`${skillName}: root SKILL.md has invalid frontmatter`);
+  }
+  return skill;
+}
+
+function parseSkill(raw) {
+  const match = raw.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n([\s\S]*)$/);
+  if (!match) return undefined;
+  const fields = {};
+  for (const line of match[1].split(/\r?\n/)) {
+    const separator = line.indexOf(':');
+    if (separator < 0) continue;
+    fields[line.slice(0, separator).trim()] = line.slice(separator + 1).trim();
+  }
+  const nameValue = fields.name;
+  const description = fields.description;
+  if (nameValue !== skillName || !description) return undefined;
+  return { name: nameValue, description, content: match[2].trim() };
+}
+
+function toCandidate(skill) {
+  return {
+    name: skill.name,
+    description: skill.description,
+    invocation: { modelInvocable: true, userInvocable: true },
+    provider: skillName,
+    source: 'bundled',
+    resourceBase: { kind: 'directory', path: resourceBase },
+    rank,
+    locator: skillPath,
+    path: skillPath,
+  };
+}
+
+function toDefinition(skill) {
+  return {
+    ...toCandidate(skill),
+    content: skill.content,
+  };
+}

--- a/package.json
+++ b/package.json
@@ -1,9 +1,16 @@
 {
   "name": "write-chinese-long-screenplay",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "中文长篇写作 skill：小说与电影/剧集长剧本双模式，含作者决策门禁、连续性台账与严格校验；兼容 Codex / Claude Code / DeepSeek Harness (dsh) / zcode",
   "type": "module",
+  "main": "index.js",
+  "exports": {
+    ".": "./index.js",
+    "./cordis.patch.yml": "./cordis.patch.yml",
+    "./package.json": "./package.json"
+  },
   "files": [
+    "index.js",
     "SKILL.md",
     "README.md",
     "README_EN.md",


### PR DESCRIPTION
## Summary

- add the missing ESM Cordis entry (`index.js`) that registers the root `SKILL.md` through `ctx.skills`
- add `main`/`exports` metadata and bump the package to v0.3.1
- correct the dsh install command and document the bundle entry

## Verification

- Node syntax check passed
- mocked `ctx.skills` registration/list/get smoke test passed
- the bundle patch still points at the package, now with a resolvable entry

This fixes the `ERR_MODULE_NOT_FOUND` startup failure reported by dsh.