### PR TITLE
ci: 发布流改为 v* tag 触发，并修复 README 中已失效的分支克隆命令

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,15 +1,14 @@
-name: publish-harness-0.4.0
+name: release
 
 on:
   push:
-    branches: [refactor/harness]
-    paths: [docs/releases/v0.4.0.md, .github/workflows/release.yml]
+    tags: ['v*']
 
 permissions:
   contents: read
 
 concurrency:
-  group: release-v0.4.0
+  group: release-${{ github.ref_name }}
   cancel-in-progress: false
 
 jobs:
@@ -35,24 +34,43 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+      - name: Require the tag to point at a commit on main
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin main
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+            echo "::error::tag $GITHUB_REF_NAME is not reachable from main"
+            exit 1
+          fi
+      - name: Require the pyproject version to match the tag
+        run: |
+          set -euo pipefail
+          version="$(python -c "import tomllib,pathlib;print(tomllib.loads(pathlib.Path('pyproject.toml').read_text('utf-8'))['project']['version'])")"
+          if [ "v$version" != "$GITHUB_REF_NAME" ]; then
+            echo "::error::pyproject.toml version is $version but tag is $GITHUB_REF_NAME"
+            exit 1
+          fi
       - name: Build wheel
         run: python -m pip wheel --no-deps --wheel-dir dist .
-      - name: Publish once without changing existing tags or releases
+      - name: Publish the tag's release once
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-          RELEASE_COMMIT: ${{ github.sha }}
         run: |
           set -euo pipefail
-          if gh release view v0.4.0 >/dev/null 2>&1; then
-            echo 'v0.4.0 already exists; preserving the published release.'
+          tag="$GITHUB_REF_NAME"
+          if gh release view "$tag" >/dev/null 2>&1; then
+            echo "$tag already exists; preserving the published release."
             exit 0
           fi
-          gh release create v0.4.0 dist/narrative_harness-0.4.0-py3-none-any.whl \
-            --target "$RELEASE_COMMIT" \
-            --title 'v0.4.0 — 泛长篇创作 Harness' \
-            --notes-file docs/releases/v0.4.0.md \
-            --latest
+          notes="docs/releases/${tag}.md"
+          if [ -f "$notes" ]; then
+            gh release create "$tag" dist/*.whl --title "$tag" --notes-file "$notes" --latest
+          else
+            gh release create "$tag" dist/*.whl --title "$tag" --generate-notes --latest
+          fi

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@
 
 ## 使用
 
-本次重构位于 [`refactor/harness`](https://github.com/mudden2380078550-creator/write-chinese-long-screenplay/tree/refactor/harness) 分支。旧版 `main` 与历史 Release 保留；下载新版请使用 [v0.4.0 Release](https://github.com/mudden2380078550-creator/write-chinese-long-screenplay/releases/tag/v0.4.0)，或明确克隆本分支：
+本项目自 v0.4.0 起采用本布局，`main` 即当前版本；旧版布局以 `legacy/` 形式保留在仓库内，历史 Release 与 tag 不受影响。下载请使用 [v0.4.0 Release](https://github.com/mudden2380078550-creator/write-chinese-long-screenplay/releases/tag/v0.4.0)，或直接克隆 `main`：
 
 ```text
-git clone --branch refactor/harness https://github.com/mudden2380078550-creator/write-chinese-long-screenplay.git narrative-harness
+git clone https://github.com/mudden2380078550-creator/write-chinese-long-screenplay.git narrative-harness
 cd narrative-harness
 ```
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -4,14 +4,14 @@ A local, model-independent state and acceptance workflow for long-form Chinese f
 
 Requires Python 3.10+. No third-party runtime dependencies. Run `python scripts/harness.py --help`, or install with `python -m pip install .` and use `harness`.
 
-Download [v0.4.0](https://github.com/mudden2380078550-creator/write-chinese-long-screenplay/releases/tag/v0.4.0), or clone the refactor branch explicitly:
+Download [v0.4.0](https://github.com/mudden2380078550-creator/write-chinese-long-screenplay/releases/tag/v0.4.0), or clone `main`, which has carried this layout since v0.4.0:
 
 ```text
-git clone --branch refactor/harness https://github.com/mudden2380078550-creator/write-chinese-long-screenplay.git narrative-harness
+git clone https://github.com/mudden2380078550-creator/write-chinese-long-screenplay.git narrative-harness
 cd narrative-harness
 ```
 
-The default `main` branch and historical releases retain the old layout. Do not copy the entire new repository into a skills directory; use the installer below. The old root-level dsh plugin layout is not the v0.4.0 entry point.
+The previous layout is retained inside the repository as `legacy/`; historical tags and releases are unchanged. Do not copy the entire new repository into a skills directory; use the installer below. The old root-level dsh plugin layout is not the v0.4.0 entry point.
 
 The lifecycle is `project new → import stage/apply → unit prepare → submit → check → accept → export`. Natural-language source extraction is performed by the host into a reviewed proposal; the source archive and unresolved sections are retained. The program does not call a model API.
 


### PR DESCRIPTION
## 背景

`release.yml` 的触发条件写死在 `refactor/harness` 分支上：

```yaml
on:
  push:
    branches: [refactor/harness]
    paths: [docs/releases/v0.4.0.md, .github/workflows/release.yml]
```

该分支在 #8 合并后已删除，所以这个发布流**再也不会触发**；版本号、notes 路径、wheel 文件名也都写死在作业里，发不出 v0.5.0。同一病根下，两处 README 仍要求用户 `git clone --branch refactor/harness`，而该分支已不存在，命令会直接失败。

（另：2026-09-09 那条 `publish-harness-0.4.0 failed` 通知的根因是 CI 环境的 Windows 编码问题，已由 e6734c7 加上 `PYTHONUTF8=1` 修复，v0.4.0 已正常发布，与本次改动无关。）

## 改动

**`.github/workflows/release.yml`** — 改名 `release`，改为推 `v*` tag 触发：

- tag 名即版本来源，不再硬编码
- 发版前校验 tag 落在 `main` 上（`git merge-base --is-ancestor`），避免从游离分支发版；因此 publish 作业改为 `fetch-depth: 0`
- 校验 `pyproject.toml` 的 `version` 与 tag 一致（wheel 文件名内嵌版本，不一致必须失败）
- notes 优先读 `docs/releases/<tag>.md`，缺失时退回 `--generate-notes`
- 去掉 `--target`（tag 已存在，再传会报错）；保留“release 已存在则跳过”的幂等保护
- concurrency 改为按 tag 分组

**`README.md` / `README_EN.md`** — 克隆命令去掉 `--branch refactor/harness`（`main` 自 v0.4.0 起即本布局，旧布局以 `legacy/` 保留）；同步更正“默认 `main` 保留旧布局”的表述。

## 验证

- `yaml.safe_load` 解析通过，`on: {push: {tags: [v*]}}`，jobs = verify/publish
- 三段 `run` 脚本逐个 `bash -n` 通过
- 版本守卫实测：pyproject `0.4.0` 匹配 `v0.4.0` 通过、`v0.4.1` 被拒
- on-main 守卫实测：main 上的提交通过；构造一个 main 之外的空提交 → 正确以 exit 1 拒绝
- README 中已无 `refactor/harness` 残留；`legacy/` 目录确实存在，新表述属实

未验证的部分：工作流只在推 tag 时才会真正运行，本次 PR 的 `harness-tests` 覆盖不到 publish 作业本身。合并后需要推一个测试 tag（如 `v0.4.1`，需先同步 bump `pyproject.toml`）才能端到端确认。
